### PR TITLE
Call `get_instance` statically

### DIFF
--- a/lib/ns_tmo_plugin.class.php
+++ b/lib/ns_tmo_plugin.class.php
@@ -93,7 +93,7 @@ class NS_TMO_Plugin {
 	/**
 	 *
 	*/
-	public function get_instance () {
+	public static function get_instance () {
 		
 		if (empty(self::$instance)) {
 			


### PR DESCRIPTION
To suppress PHP error message when calling plugin.
